### PR TITLE
don't define EIGEN_INCLUDE_DIR and let cmake finds it automatically

### DIFF
--- a/camera_model/CMakeLists.txt
+++ b/camera_model/CMakeLists.txt
@@ -15,7 +15,6 @@ include_directories(${Boost_INCLUDE_DIRS})
 
 find_package(OpenCV REQUIRED)
 
-set(EIGEN_INCLUDE_DIR "/usr/local/include/eigen3")
 find_package(Ceres REQUIRED)
 include_directories(${CERES_INCLUDE_DIRS})
 


### PR DESCRIPTION
When using the Ubuntu eigen3 package, which is installed to `/usr` instead of `/usr/local`, there would be CMake error as follows:

```
catkin_make --use-ninja
Base path: /catkin_ws
Source space: /catkin_ws/src
Build space: /catkin_ws/build
Devel space: /catkin_ws/devel
Install space: /catkin_ws/install
####
#### Running command: "cmake /catkin_ws/src -DCATKIN_DEVEL_PREFIX=/catkin_ws/devel -DCMAKE_INSTALL_PREFIX=/catkin_ws/install -G Ninja" in "/catkin_ws/build"
####
-- Using CATKIN_DEVEL_PREFIX: /catkin_ws/devel
-- Using CMAKE_PREFIX_PATH: /opt/ros/indigo
-- This workspace overlays: /opt/ros/indigo
-- Using PYTHON_EXECUTABLE: /usr/bin/python
-- Using Debian Python package layout
-- Using empy: /usr/bin/empy
-- Using CATKIN_ENABLE_TESTING: ON
-- Call enable_testing()
-- Using CATKIN_TEST_RESULTS_DIR: /catkin_ws/build/test_results
-- Found gtest sources under '/usr/src/gtest': gtests will be built
-- Using Python nosetests: /usr/bin/nosetests-2.7
-- catkin 0.6.19
-- BUILD_SHARED_LIBS is on
-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-- ~~  traversing 9 packages in topological order:
-- ~~  - open_chisel
-- ~~  - perception_pcl (metapackage)
-- ~~  - camera_model
-- ~~  - feature_tracker
-- ~~  - self_calibration_estimator
-- ~~  - stereo_mapper
-- ~~  - pcl_ros
-- ~~  - chisel_ros
-- ~~  - pointcloud_to_laserscan
-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-- +++ processing catkin package: 'open_chisel'
-- ==> add_subdirectory(VI-MEAN/OpenChisel/open_chisel)
-- Eigen found (include: /usr/include/eigen3)
-- +++ processing catkin metapackage: 'perception_pcl'
-- ==> add_subdirectory(perception_pcl-indigo-devel/perception_pcl)
-- +++ processing catkin package: 'camera_model'
-- ==> add_subdirectory(VI-MEAN/camera_model)
-- Boost version: 1.54.0
-- Found the following Boost libraries:
--   filesystem
--   program_options
--   system
-- Failed to find Eigen - Could not find eigen3 include directory, set EIGEN_INCLUDE_DIR to path to eigen3 include directory, e.g. /usr/local/include/eigen3.
CMake Error at /usr/local/lib/cmake/Ceres/CeresConfig.cmake:88 (message):
  Failed to find Ceres - Missing required Ceres dependency: Eigen version
  3.2.0, please set EIGEN_INCLUDE_DIR.
Call Stack (most recent call first):
  /usr/local/lib/cmake/Ceres/CeresConfig.cmake:227 (ceres_report_not_found)
  VI-MEAN/camera_model/CMakeLists.txt:19 (find_package)


CMake Error at VI-MEAN/camera_model/CMakeLists.txt:19 (find_package):
  Found package configuration file:

    /usr/local/lib/cmake/Ceres/CeresConfig.cmake

  but it set Ceres_FOUND to FALSE so package "Ceres" is considered to be NOT
  FOUND.


-- Configuring incomplete, errors occurred!
See also "/catkin_ws/build/CMakeFiles/CMakeOutput.log".
See also "/catkin_ws/build/CMakeFiles/CMakeError.log".
Invoking "cmake" failed
```